### PR TITLE
GR-1282 extend onDisconnection handler to receive errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,9 +1,10 @@
 package gosocketio
 
 import (
-	"github.com/graarh/golang-socketio/protocol"
-	"github.com/graarh/golang-socketio/transport"
 	"strconv"
+
+	"github.com/paxosglobal/golang-socketio/protocol"
+	"github.com/paxosglobal/golang-socketio/transport"
 )
 
 const (

--- a/examples/client.go
+++ b/examples/client.go
@@ -1,18 +1,19 @@
 package main
 
 import (
-	"github.com/graarh/golang-socketio"
-	"github.com/graarh/golang-socketio/transport"
 	"log"
 	"runtime"
 	"time"
+
+	"github.com/paxosglobal/golang-socketio"
+	"github.com/paxosglobal/golang-socketio/transport"
 )
 
-type Channel struct {
+type ChannelClient struct {
 	Channel string `json:"channel"`
 }
 
-type Message struct {
+type MessageClient struct {
 	Id      int    `json:"id"`
 	Channel string `json:"channel"`
 	Text    string `json:"text"`
@@ -20,9 +21,9 @@ type Message struct {
 
 func sendJoin(c *gosocketio.Client) {
 	log.Println("Acking /join")
-	result, err := c.Ack("/join", Channel{"main"}, time.Second*5)
+	result, err := c.Ack("/join", ChannelClient{"main"}, time.Second*5)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("error acking join:", err)
 	} else {
 		log.Println("Ack result to /join: ", result)
 	}
@@ -38,15 +39,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = c.On("/message", func(h *gosocketio.Channel, args Message) {
+	err = c.On("/message", func(h *gosocketio.Channel, args MessageClient) {
 		log.Println("--- Got chat message: ", args)
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = c.On(gosocketio.OnDisconnection, func(h *gosocketio.Channel) {
-		log.Fatal("Disconnected")
+	err = c.On(gosocketio.OnDisconnection, func(h *gosocketio.Channel, errors interface{}) {
+		log.Fatal("Disconnected... ", errors)
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -67,7 +68,7 @@ func main() {
 	go sendJoin(c)
 	go sendJoin(c)
 
-	time.Sleep(60 * time.Second)
+	time.Sleep(10 * time.Second)
 	c.Close()
 
 	log.Println(" [x] Complete")

--- a/examples/client.go
+++ b/examples/client.go
@@ -9,11 +9,11 @@ import (
 	"github.com/paxosglobal/golang-socketio/transport"
 )
 
-type ChannelClient struct {
+type ClientChannel struct {
 	Channel string `json:"channel"`
 }
 
-type MessageClient struct {
+type ClientMessage struct {
 	Id      int    `json:"id"`
 	Channel string `json:"channel"`
 	Text    string `json:"text"`
@@ -21,7 +21,7 @@ type MessageClient struct {
 
 func sendJoin(c *gosocketio.Client) {
 	log.Println("Acking /join")
-	result, err := c.Ack("/join", ChannelClient{"main"}, time.Second*5)
+	result, err := c.Ack("/join", ClientChannel{"main"}, time.Second*5)
 	if err != nil {
 		log.Fatal("error acking join:", err)
 	} else {
@@ -39,7 +39,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = c.On("/message", func(h *gosocketio.Channel, args MessageClient) {
+	err = c.On("/message", func(h *gosocketio.Channel, args ClientMessage) {
 		log.Println("--- Got chat message: ", args)
 	})
 	if err != nil {

--- a/examples/server.go
+++ b/examples/server.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/graarh/golang-socketio"
-	"github.com/graarh/golang-socketio/transport"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/paxosglobal/golang-socketio"
+	"github.com/paxosglobal/golang-socketio/transport"
 )
 
 type Channel struct {
@@ -24,7 +25,7 @@ func main() {
 	server.On(gosocketio.OnConnection, func(c *gosocketio.Channel) {
 		log.Println("Connected")
 
-		c.Emit("/message", Message{10, "main", "using emit"})
+		c.Emit("/message", "/test", Message{10, "main", "using emit"})
 
 		c.Join("test")
 		c.BroadcastTo("test", "/message", Message{10, "main", "using broadcast"})

--- a/protocol/socketio.go
+++ b/protocol/socketio.go
@@ -125,16 +125,19 @@ func getAck(text string) (ackId int, restText string, err error) {
 	text = text[2:]
 
 	pos := strings.IndexByte(text, '[')
+	payloadIdx := pos
 	if pos == -1 {
 		return 0, "", ErrorWrongPacket
 	}
-
+	if p := strings.IndexByte(text[0:pos], ','); p >=0 {
+		pos = p
+	}
 	ack, err := strconv.Atoi(text[0:pos])
 	if err != nil {
 		return 0, "", err
 	}
 
-	return ack, text[pos:], nil
+	return ack, text[payloadIdx:], nil
 }
 
 /**

--- a/send.go
+++ b/send.go
@@ -3,9 +3,10 @@ package gosocketio
 import (
 	"encoding/json"
 	"errors"
-	"github.com/graarh/golang-socketio/protocol"
 	"log"
 	"time"
+
+	"github.com/paxosglobal/golang-socketio/protocol"
 )
 
 var (

--- a/server.go
+++ b/server.go
@@ -7,12 +7,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/graarh/golang-socketio/protocol"
-	"github.com/graarh/golang-socketio/transport"
 	"math/rand"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/paxosglobal/golang-socketio/protocol"
+	"github.com/paxosglobal/golang-socketio/transport"
 )
 
 const (


### PR DESCRIPTION
Local tests:
First, creating a test only Close function that calls `closeChannel` with errors (as it is done in the `inLoop` function)
![Screen Shot 2020-10-13 at 19 28 39](https://user-images.githubusercontent.com/9322001/95923969-062b8f80-0d8d-11eb-8324-0c4dd04aaa89.png)

Output:
<img width="1110" alt="Screen Shot 2020-10-13 at 19 32 44" src="https://user-images.githubusercontent.com/9322001/95924054-307d4d00-0d8d-11eb-8b3a-78f2ec6ee920.png">


Example just killing the server
<img width="1291" alt="Screen Shot 2020-10-13 at 20 13 48" src="https://user-images.githubusercontent.com/9322001/95925624-af27b980-0d90-11eb-850f-8b80a31d9390.png">
